### PR TITLE
Ignore non-5xx errors using Plug.Exception.status/1

### DIFF
--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -4,18 +4,25 @@ defmodule Plugsnag do
       use Plug.ErrorHandler
       import Plugsnag
 
-      # We don't want to bugsnag for errors which have plug_status and plug_status is valid < 500
-      defp handle_errors(_conn, %{reason: %{plug_status: plug_status}}) when plug_status < 500 do
-        nil
-      end
-
-      if :code.is_loaded(Ecto) do
-        defp handle_errors(conn, %{reason: %Ecto.NoResultsError{}}) do
+      defp handle_errors(conn, %{reason: exception, kind: :error} = assigns) do
+        # Ignore exceptions that don't get rendered as an HTTP 5xx status.
+        # These don't really represent unhandled exceptions, and so don't
+        # make sense to be sent off to Bugsnag.
+        # To extend this behaviour to an otherwise unhandled exception type,
+        # provide an implementation of the Plug.Exception protocol for your
+        # exception type.
+        if Plug.Exception.status(exception) < 500 do
           nil
+        else
+          do_handle_errors(conn, assigns)
         end
       end
 
-      defp handle_errors(conn, %{reason: exception}) do
+      defp handle_errors(conn, %{reason: _exception} = assigns) do
+        do_handle_errors(conn, assigns)
+      end
+
+      defp do_handle_errors(conn, %{reason: exception}) do
         error_report_builder = unquote(
           Keyword.get(
             options,

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Plugsnag.Mixfile do
 
   def project do
     [app: :plugsnag,
-     version: "1.4.0",
+     version: "1.4.1",
      elixir: "~> 1.0",
      package: package(),
      description: """


### PR DESCRIPTION
`phoenix_ecto` provides an implementation of the `Plug.Exception` protocol for [several of its exception types](https://github.com/phoenixframework/phoenix_ecto/blob/master/lib/phoenix_ecto/plug.ex#L12), which has the result of rendering non-5xx HTTP responses for these exception types.

`Ecto.NoResultsError` is one of these types, and gets rendered as an HTTP 404, which is why an explicit function clause exempting it from Bugsnagging isn't necessary anymore.

@PagerDuty/im-data for review.